### PR TITLE
fix: take multiple style reference images from one_style.json

### DIFF
--- a/custom/custom_dataset.py
+++ b/custom/custom_dataset.py
@@ -103,8 +103,9 @@ class train_custom_dataset(Dataset):
         print(self.image[0])
         print("-----------------"*3)
     def __getitem__(self, index):
-        prompt = self.prompt[0]
-        image = Image.open(self.image[0]).convert("RGB")
+        index = index % len(self.image)
+        prompt = self.prompt[index]
+        image = Image.open(self.image[index]).convert("RGB")
         image = self.transform(image)
         
         return image,prompt


### PR DESCRIPTION
Hi, hope I don't bother you.

I was using your cool implementation for a recent university project of mine where I compare a few style-adjustment architectures - anyways.

At some point I noticed, that I was getting the exact same training results for putting only one description into `one_style.json` - like this:
```
"Graffiti/00.jpg":["An open mouth with tongue", "in graffiti style"]
```
or multiple - as long as the first image was the same - like this:
```
    "Graffiti/00.jpg":["An open mouth with tongue", "in graffiti style"],
    "Graffiti/01.jpg":["Love Peace Joy written", "in graffiti style"],
```
And I kinda noticed that late ... like: At my twentieth trainings-run or so. At this point I already had started to believe that the model always tends to over-fit on specific textures and the results simply never get as good for me as in the provided examples.

Which kinda makes sense, if I **always** overfit on exactly one training image - my first. *Because all the other listed images in one_style.json are silently ignored*. So ... changing these lines helped me to (finally!) get good results at the end. And this fix is kinda not very obvious.

So maybe you think about it.

Cheers~